### PR TITLE
Allow parametrized socket path and state dir

### DIFF
--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -41,8 +41,8 @@ var stateFileFunc func() string
 // tailscaled state file, or the empty string if there's no reasonable
 // default value.
 func DefaultTailscaledStateFile() string {
-	if state := os.Getenv("TS_STATE_DIR"); state != "" {
-		return state
+	if statedir := os.Getenv("TS_STATE_DIR"); statedir != "" {
+		return filepath.Join(statedir, "tailscaled.state")
 	}
 	if f := stateFileFunc; f != nil {
 		return f()

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -20,6 +20,9 @@ var AppSharedDir atomic.Value
 // DefaultTailscaledSocket returns the path to the tailscaled Unix socket
 // or the empty string if there's no reasonable default.
 func DefaultTailscaledSocket() string {
+	if socket := os.Getenv("TS_SOCKET"); socket != "" {
+		return socket
+	}
 	if runtime.GOOS == "windows" {
 		return `\\.\pipe\ProtectedPrefix\Administrators\Tailscale\tailscaled`
 	}
@@ -38,6 +41,9 @@ var stateFileFunc func() string
 // tailscaled state file, or the empty string if there's no reasonable
 // default value.
 func DefaultTailscaledStateFile() string {
+	if state := os.Getenv("TS_STATE_DIR"); state != "" {
+		return state
+	}
 	if f := stateFileFunc; f != nil {
 		return f()
 	}


### PR DESCRIPTION
Tailscale container image supports the following env variables to set the socket path and state dir, this PR adds them to tscert so it can be used in [Traefik](https://github.com/traefik/traefik/blob/619045eb4bbe842be550fd16d67dc7c8eb61ebe8/pkg/provider/tailscale/provider.go#L13) for example.

- [TS_STATE_DIR](https://github.com/tailscale/tailscale/blob/e8b06b22323668b28ac4f950b8b8963922d4f8bf/cmd/containerboot/main.go#L84)
- [TS_SOCKET](https://github.com/tailscale/tailscale/blob/e8b06b22323668b28ac4f950b8b8963922d4f8bf/cmd/containerboot/main.go#L89)

Fixes #3 