### PR TITLE
go.mod: switch to minimum go version of 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tailscale/tscert
 
-go 1.25.5
+go 1.25
 
 require (
 	github.com/mitchellh/go-ps v1.0.0


### PR DESCRIPTION
This matches [what caddy is currently using](https://github.com/caddyserver/caddy/blob/master/go.mod), which is the primary user of this package.  This prevents forcing caddy to bump their go version when updating to the latest version of this package.

Updates #15